### PR TITLE
Add payload validation to bot simulator API

### DIFF
--- a/src/pages/api/bot-simulate.js
+++ b/src/pages/api/bot-simulate.js
@@ -1,6 +1,17 @@
 export async function POST({ request }) {
   try {
     const { command, params, pools } = await request.json();
+
+    // Validate payload before processing
+    if (!isValidRequest(command, params, pools)) {
+      return new Response(
+        JSON.stringify({ response: '❌ Invalid request payload' }),
+        {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' }
+        }
+      );
+    }
     
     // Parse command
     const commandParts = command.trim().split(' ');
@@ -80,6 +91,33 @@ const getMockOrderData = () => ({
   notes: 'Leave at door',
   tip: '5.00'
 });
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isValidPools(pools) {
+  return (
+    isPlainObject(pools) &&
+    Array.isArray(pools.cards) &&
+    pools.cards.every(c => typeof c === 'string') &&
+    Array.isArray(pools.emails) &&
+    pools.emails.every(e => typeof e === 'string')
+  );
+}
+
+function isValidRequest(command, params, pools) {
+  if (typeof command !== 'string' || !command.trim().startsWith('/')) {
+    return false;
+  }
+  if (!isPlainObject(params)) {
+    return false;
+  }
+  if (!isValidPools(pools)) {
+    return false;
+  }
+  return true;
+}
 
 async function handleFusionAssist(params, pools) {
   if (pools.cards.length === 0) {


### PR DESCRIPTION
## Summary
- validate request body fields before executing bot commands
- add utility functions for validation and early 400 response

## Testing
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843155eb724832e928855702c3a1191