### PR TITLE
Fix closing anchor in mobile menu

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -57,7 +57,6 @@ import Button from './ui/Button.astro';
       <a href="#experience" class="font-medium py-2 hover:text-primary transition-colors">Experience</a>
       <!-- <a href="#skills" class="font-medium py-2 hover:text-primary transition-colors">Skills</a> -->
       <a href="#contact" class="font-medium py-2 hover:text-primary transition-colors">Contact</a>
-      </a>
     </div>
   </div>
 </header>


### PR DESCRIPTION
## Summary
- remove stray closing `</a>` tag from `Header.astro`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6843155cb250832eb04464b4f4c73e50